### PR TITLE
feat(api): Implement session management using @remix-run/node

### DIFF
--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -47,7 +47,7 @@ const Sidebar: React.FC = () => {
   return (
     <div className="sidebar ">
       <Nav className="flex-column w-100">
-        <SidebarItem label="CODEBUDDY" />
+        <SidebarItem label="Why Code Buddy" />
         <SidebarItem label="Feature Guide" />
         <SidebarItem label="Overview" />
         <SidebarItem label="Chat">

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -1,0 +1,71 @@
+import { createCookieSessionStorage, redirect, Session, SessionData, SessionStorage } from "@remix-run/node";
+import invariant from "tiny-invariant";
+
+export class SessionManager {
+  private readonly sessionStorage: SessionStorage<SessionData, SessionData>;
+  private readonly USER_SESSION_KEY = "userId";
+
+  constructor() {
+    invariant(process.env.SESSION_SECRET, "SESSION_SECRET must be set");
+    this.sessionStorage = createCookieSessionStorage({
+      cookie: {
+        name: "",
+        httpOnly: true,
+        path: "/",
+        sameSite: "lax",
+        secrets: [process.env.SESSION_SECRET],
+        secure: process.env.NODE_ENV === "production",
+      },
+    });
+  }
+
+  async getSession(request: Request): Promise<Session<SessionData, SessionData>> {
+    return await this.sessionStorage.getSession(request.headers.get("Cookie"));
+  }
+
+  async getUserId(request: Request): Promise<string> {
+    const session = await this.getSession(request);
+    const userId = session.get("userId");
+    return userId;
+  }
+
+  async requireUserId(request: Request, redirectTo: string = new URL(request.url).pathname): Promise<string> {
+    const userId = await this.getUserId(request);
+    if (!userId) {
+      const searchParams = new URLSearchParams([["redirectTo", redirectTo]]);
+      throw redirect(`/login?${searchParams}`);
+    }
+    return userId;
+  }
+
+  async createUserSession({
+    request,
+    userId,
+    remember,
+    redirectTo,
+  }: {
+    request: Request;
+    userId: string;
+    remember: boolean;
+    redirectTo: string;
+  }) {
+    const session = await this.getSession(request);
+    session.set(this.USER_SESSION_KEY, userId);
+    return redirect(redirectTo, {
+      headers: {
+        "Set-Cookie": await this.sessionStorage.commitSession(session, {
+          maxAge: remember ? 3600 * 24 * 7 : undefined,
+        }),
+      },
+    });
+  }
+
+  async logOut(request: Request) {
+    const session = await this.getSession(request);
+    return redirect("/", {
+      headers: {
+        "Set-Cookie": await this.sessionStorage.destroySession(session),
+      },
+    });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.10.4",
         "react-bootstrap-sidebar-menu": "^2.0.3",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "tiny-invariant": "^1.3.3"
       },
       "devDependencies": {
         "@remix-run/dev": "^2.10.2",
@@ -10232,6 +10233,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.4",
     "react-bootstrap-sidebar-menu": "^2.0.3",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.10.2",


### PR DESCRIPTION
Added SessionManager class to manage sessions in the server-side API Implemented session management using @remix-run/node package Added requireUserId and createUserSession methods to manage user sessions Updated package-lock.json and package.json files to include the new dependency tiny-invariant